### PR TITLE
fix(jei): avoid modifying itemstack instance

### DIFF
--- a/src/main/java/com/portingdeadmods/nautec/content/recipes/utils/RecipeUtils.java
+++ b/src/main/java/com/portingdeadmods/nautec/content/recipes/utils/RecipeUtils.java
@@ -21,11 +21,7 @@ public final class RecipeUtils {
     }
 
     public static @NotNull Ingredient iWCToIngredientSaveCount(IngredientWithCount ingredientWithCount) {
-        Ingredient ingredient = ingredientWithCount.ingredient();
-        for (ItemStack itemStack : ingredient.getItems()) {
-            itemStack.setCount(ingredientWithCount.count());
-        }
-        return ingredient;
+        return Ingredient.of(Stream.of(ingredientWithCount.ingredient().getItems()).map(s -> s.copyWithCount(ingredientWithCount.count())));
     }
 
     public static <T> NonNullList<T> listToNonNullList(List<T> list) {


### PR DESCRIPTION
Hello 👋 , I'm making this PR to this mod to add compatibility to a feature (Ingredient Deduplication) on my mod (AllTheLeaks) that relies heavily on modders to not modify the inner stack of those ingredients.

I would greatly appreciate it if you could accept this PR.

Thanks.